### PR TITLE
ZCS-8012 : Upgrade jquery in zm-admin-console

### DIFF
--- a/WebRoot/js/ajax/package/Ajax.js
+++ b/WebRoot/js/ajax/package/Ajax.js
@@ -137,6 +137,3 @@ AjxPackage.require("ajax.dwt.widgets.DwtRadioButtonGroup");
 AjxPackage.require("ajax.dwt.widgets.DwtForm");
 AjxPackage.require("ajax.dwt.widgets.DwtComboBox");
 AjxPackage.require("ajax.dwt.widgets.DwtTimeSelect");
-
-AjxPackage.require("ajax.3rdparty.jquery.jquery");
-

--- a/WebRoot/js/ajax/package/Clipboard.js
+++ b/WebRoot/js/ajax/package/Clipboard.js
@@ -1,0 +1,25 @@
+
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Web Client
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2018 Synacor, Inc.
+ *
+ * The contents of this file are subject to the Common Public Attribution License Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at: https://www.zimbra.com/license
+ * The License is based on the Mozilla Public License Version 1.1 but Sections 14 and 15
+ * have been added to cover use of software over a computer network and provide for limited attribution
+ * for the Original Developer. In addition, Exhibit A has been modified to be consistent with Exhibit B.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ * See the License for the specific language governing rights and limitations under the License.
+ * The Original Code is Zimbra Open Source Web Client.
+ * The Initial Developer of the Original Code is Zimbra, Inc.  All rights to the Original Code were
+ * transferred by Zimbra, Inc. to Synacor, Inc. on September 14, 2015.
+ *
+ * All portions of the code are Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2018 Synacor, Inc. All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+// by default all 3rd party libraries will be shipped in minified version only as there will not be many instances where we will need to debug 3rd party code
+AjxPackage.require("ajax.3rdparty.clipboard_min"); 

--- a/WebRoot/js/ajax/package/JQuery.js
+++ b/WebRoot/js/ajax/package/JQuery.js
@@ -1,0 +1,24 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Web Client
+ * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2018 Synacor, Inc.
+ *
+ * The contents of this file are subject to the Common Public Attribution License Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at: https://www.zimbra.com/license
+ * The License is based on the Mozilla Public License Version 1.1 but Sections 14 and 15
+ * have been added to cover use of software over a computer network and provide for limited attribution
+ * for the Original Developer. In addition, Exhibit A has been modified to be consistent with Exhibit B.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ * See the License for the specific language governing rights and limitations under the License.
+ * The Original Code is Zimbra Open Source Web Client.
+ * The Initial Developer of the Original Code is Zimbra, Inc.  All rights to the Original Code were
+ * transferred by Zimbra, Inc. to Synacor, Inc. on September 14, 2015.
+ *
+ * All portions of the code are Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2018 Synacor, Inc. All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+// by default all 3rd party libraries will be shipped in minified version only as there will not be many instances where we will need to debug 3rd party code
+AjxPackage.require("ajax.3rdparty.jquery.jquery_min");

--- a/WebRoot/js/ajax/util/AjxClipboard.js
+++ b/WebRoot/js/ajax/util/AjxClipboard.js
@@ -28,7 +28,7 @@
  * @constructor
  */
 AjxClipboard = function() {
-
+	AjxDispatcher.require("Clipboard");
 };
 
 /**


### PR DESCRIPTION
- Moving jquery and clipboard code to its own modules
- Not minifying the 3rd party code using yiucomposser instead using the minified versionthat is shipped with the 3rd party lib
- Loading Jquery is loaded before itself has it is happening now
- Upgrading jquery version to 3.4.1